### PR TITLE
Added possibility to format and parse int64/uint64/sint64 as JSON string

### DIFF
--- a/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
+++ b/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
@@ -32,6 +32,7 @@ case class FormatRegistry(mapClass: Map[Class[_], (_ => JValue, JValue => _)] = 
 class Printer(
   includingDefaultValueFields: Boolean = false,
   preservingProtoFieldNames: Boolean = false,
+  formattingLongAsString: Boolean = false,
   formatRegistry: FormatRegistry = JsonFormat.DefaultRegistry) {
 
   def print[A](m: GeneratedMessage): String = {
@@ -90,7 +91,7 @@ class Printer(
     case JavaType.ENUM => JString(value.asInstanceOf[EnumValueDescriptor].getName)
     case JavaType.MESSAGE => toJson(value.asInstanceOf[GeneratedMessage])
     case JavaType.INT => JInt(value.asInstanceOf[Int])
-    case JavaType.LONG => JLong(value.asInstanceOf[Long])
+    case JavaType.LONG => if (formattingLongAsString) JString(Option(value).map(_.toString).orNull) else JLong(value.asInstanceOf[Long])
     case JavaType.DOUBLE => JDouble(value.asInstanceOf[Double])
     case JavaType.FLOAT => JDouble(value.asInstanceOf[Float])
     case JavaType.BOOLEAN => JBool(value.asInstanceOf[Boolean])
@@ -180,6 +181,7 @@ class Parser(formatRegistry: FormatRegistry = JsonFormat.DefaultRegistry) {
     case (JavaType.INT, JNull) => 0
     case (JavaType.LONG, JLong(x)) => x.toLong
     case (JavaType.LONG, JDecimal(x)) => x.longValue()
+    case (JavaType.LONG, JString(x)) => x.toLong
     case (JavaType.LONG, JInt(x)) => x.toLong
     case (JavaType.LONG, JNull) => 0L
     case (JavaType.DOUBLE, JDouble(x)) => x

--- a/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
+++ b/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
@@ -32,7 +32,7 @@ case class FormatRegistry(mapClass: Map[Class[_], (_ => JValue, JValue => _)] = 
 class Printer(
   includingDefaultValueFields: Boolean = false,
   preservingProtoFieldNames: Boolean = false,
-  formattingLongAsString: Boolean = false,
+  formattingLongAsString: Boolean = true,
   formatRegistry: FormatRegistry = JsonFormat.DefaultRegistry) {
 
   def print[A](m: GeneratedMessage): String = {
@@ -91,7 +91,7 @@ class Printer(
     case JavaType.ENUM => JString(value.asInstanceOf[EnumValueDescriptor].getName)
     case JavaType.MESSAGE => toJson(value.asInstanceOf[GeneratedMessage])
     case JavaType.INT => JInt(value.asInstanceOf[Int])
-    case JavaType.LONG => if (formattingLongAsString) JString(Option(value).map(_.toString).orNull) else JLong(value.asInstanceOf[Long])
+    case JavaType.LONG => if (formattingLongAsString) JString(value.asInstanceOf[Long].toString) else JLong(value.asInstanceOf[Long])
     case JavaType.DOUBLE => JDouble(value.asInstanceOf[Double])
     case JavaType.FLOAT => JDouble(value.asInstanceOf[Float])
     case JavaType.BOOLEAN => JBool(value.asInstanceOf[Boolean])

--- a/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
+++ b/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
@@ -163,4 +163,16 @@ class JsonFormatSpec extends FlatSpec with MustMatchers {
           |}""".stripMargin)
     )
   }
+
+  "TestProto" should "format int64 as JSON string" in {
+    new Printer(formattingLongAsString = true).print(MyTest(bazinga = Some(642))) must be("""{"bazinga":"642"}""")
+  }
+
+  "TestProto" should "format int64 as JSON number" in {
+    new Printer().print(MyTest(bazinga = Some(642))) must be("""{"bazinga":642}""")
+  }
+
+  "TestProto" should "parse a number formatted as JSON string " in {
+    new Parser().fromJsonString[MyTest]("""{"bazinga":642}""") must be(MyTest(bazinga = Some(642)))
+  }
 }

--- a/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
+++ b/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
@@ -165,11 +165,11 @@ class JsonFormatSpec extends FlatSpec with MustMatchers {
   }
 
   "TestProto" should "format int64 as JSON string" in {
-    new Printer(formattingLongAsString = true).print(MyTest(bazinga = Some(642))) must be("""{"bazinga":"642"}""")
+    new Printer().print(MyTest(bazinga = Some(642))) must be("""{"bazinga":"642"}""")
   }
 
   "TestProto" should "format int64 as JSON number" in {
-    new Printer().print(MyTest(bazinga = Some(642))) must be("""{"bazinga":642}""")
+    new Printer(formattingLongAsString = false).print(MyTest(bazinga = Some(642))) must be("""{"bazinga":642}""")
   }
 
   "TestProto" should "parse a number formatted as JSON string " in {


### PR DESCRIPTION
Fixes https://github.com/scalapb/ScalaPB/issues/199