### PR TITLE
Make Parser.fromJsonToPMessage public

### DIFF
--- a/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
+++ b/src/main/scala/com/trueaccord/scalapb/json/JsonFormat.scala
@@ -193,7 +193,7 @@ class Parser(
     if (preservingProtoFieldNames) fd.asProto.getName else JsonFormat.jsonName(fd)
   }
 
-  private def fromJsonToPMessage(cmp: GeneratedMessageCompanion[_], value: JValue): PMessage = {
+  def fromJsonToPMessage(cmp: GeneratedMessageCompanion[_], value: JValue): PMessage = {
 
     def parseValue(fd: FieldDescriptor, value: JValue): PValue = {
       if (fd.isMapField) {

--- a/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
+++ b/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
@@ -116,7 +116,6 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues {
   }
 
   "TestProto" should "be TestJson when converted to Proto" in {
-    println("---------------------------")
     JsonFormat.toJson(TestProto) must be (parse(TestJson))
   }
 
@@ -198,6 +197,11 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues {
   "TestProto" should "parse an enum formatted as number" in {
     new Parser().fromJsonString[MyTest]("""{"optEnum":1}""") must be(MyTest(optEnum = Some(MyEnum.V1)))
     new Parser().fromJsonString[MyTest]("""{"optEnum":2}""") must be(MyTest(optEnum = Some(MyEnum.V2)))
+  }
+
+  "TestProto" should "parse a JValue to PMessage" in {
+    val pMessage = new Parser().fromJsonToPMessage(MyTest.messageCompanion, parse(TestJson))
+    MyTest.messageCompanion.messageReads.read(pMessage) must be(TestProto)
   }
 
   "PreservedTestJson" should "be TestProto when parsed from json" in {


### PR DESCRIPTION
ScalaPB relies on Scala features much: i.e. implicit evidences in parse methods. That is absolutely cool and makes source code type safe.

But in our case we have to call JsonFormat from Jackson ObjectMapper. The only thing provided there is Class[_]. We can convert a class (of a message being parsed) to a message companion (using ugly reflection hacks). If only Parser.fromJsonToPMessage method was public, we would be able to complete our task.

Indeed, making fromJsonToPMessage public reveals too much (i.e. internal PMessage), but I am pretty sure this PR would extend this perfect library usability.