### PR TITLE
JsonFormat from scalapb-json4s is unable to deal with custom collection type (scalapb issue #376)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ releaseProcess := Seq[ReleaseStep](
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
+  "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf",
   "org.json4s" %% "json4s-jackson" % "3.5.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.google.protobuf" % "protobuf-java-util" % "3.4.0" % "test",

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -122,7 +122,7 @@ class Printer(
         if (includingDefaultValueFields) {
           b += JField(name, if (fd.isMapField) JObject() else JArray(Nil))
         }
-      case xs: Seq[GeneratedMessage] @unchecked =>
+      case xs: Iterable[GeneratedMessage] @unchecked =>
         if (fd.isMapField) {
           val mapEntryDescriptor = fd.scalaType.asInstanceOf[ScalaType.Message].descriptor
           val keyDescriptor = mapEntryDescriptor.findFieldByNumber(1).get
@@ -145,7 +145,7 @@ class Printer(
                   serializeSingleValue(valueDescriptor, x.getField(valueDescriptor), formattingLongAsNumber)
                 }
                 key -> value
-            }: _*))
+            }.toSeq: _*))
         } else {
           b += JField(name, JArray(xs.map(toJson).toList))
         }

--- a/src/test/protobuf/custom_collection.proto
+++ b/src/test/protobuf/custom_collection.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "jsontest";
+import "scalapb/scalapb.proto";
+
+message Guitar {
+  int32 number_of_strings = 1;
+}
+
+message Studio {
+  repeated Guitar guitars = 1 [(scalapb.field).collection_type = "Set"];
+}

--- a/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
+++ b/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
@@ -391,11 +391,19 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues {
     anyEnabledParser.fromJsonString[PBAny](javaJson).unpack[MyTest] must be(TestProto)
   }
 
-  "Custom Collection Type" should "parse JSON correctly" in {
+  "toJsonString" should "generate correct JSON for messages with custom collection type" in {
     val studio = Studio().addGuitars(Guitar(numberOfStrings = 12))
     val expectedStudioJsonString = """{"guitars":[{"numberOfStrings":12}]}"""
     val studioJsonString = JsonFormat.toJsonString(studio)
     studioJsonString must be(expectedStudioJsonString)
+  }
+
+  "fromJsonString" should "parse JSON correctly to message with custom collection type" in {
+    val expectedStudio = Studio().addGuitars(Guitar(numberOfStrings = 12))
+    val studioJsonString = """{"guitars":[{"numberOfStrings":12}]}"""
+    import Studio.messageCompanion
+    val studio = JsonFormat.fromJsonString(studioJsonString)
+    studio must be(expectedStudio)
   }
   
 }

--- a/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
+++ b/src/test/scala/com/trueaccord/scalapb/json/JsonFormatSpec.scala
@@ -9,6 +9,7 @@ import jsontest.test3._
 import com.google.protobuf.util.{JsonFormat => JavaJsonFormat}
 import com.google.protobuf.any.{Any => PBAny}
 import com.google.protobuf.util.JsonFormat.{TypeRegistry => JavaTypeRegistry}
+import jsontest.custom_collection.{Guitar, Studio}
 
 class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues {
 
@@ -388,6 +389,13 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues {
     val javaAny = com.google.protobuf.Any.pack(MyTest.toJavaProto(TestProto))
     val javaJson = anyEnabledJavaPrinter.print(javaAny)
     anyEnabledParser.fromJsonString[PBAny](javaJson).unpack[MyTest] must be(TestProto)
+  }
+
+  "Custom Collection Type" should "parse JSON correctly" in {
+    val studio = Studio().addGuitars(Guitar(numberOfStrings = 12))
+    val expectedStudioJsonString = """{"guitars":[{"numberOfStrings":12}]}"""
+    val studioJsonString = JsonFormat.toJsonString(studio)
+    studioJsonString must be(expectedStudioJsonString)
   }
   
 }


### PR DESCRIPTION
use Iterable (super-type of Set and Seq) in JsonFormat to support more collection types.