### PR TITLE
Serialize FieldMask to comma separated string

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.15")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.0-RC1"
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import scala.language.existentials
 import scala.reflect.ClassTag
 import _root_.scalapb.descriptors._
+import com.google.protobuf.field_mask.FieldMask
 
 case class JsonFormatException(msg: String, cause: Exception) extends Exception(msg, cause) {
   def this(msg: String) = this(msg, null)
@@ -415,6 +416,10 @@ object JsonFormat {
     })
     .registerWriter((t: Timestamp) => JString(Timestamps.writeTimestamp(t)), jv => jv match {
       case JString(str) => Timestamps.parseTimestamp(str)
+      case _ => throw new JsonFormatException("Expected a string.")
+    })
+    .registerWriter((m: FieldMask) => JString(m.paths.mkString(",")), jv => jv match {
+      case JString(str) => FieldMask(if (str.isEmpty) Nil else str.split(','))
       case _ => throw new JsonFormatException("Expected a string.")
     })
     .registerMessageFormatter[wrappers.DoubleValue](primitiveWrapperWriter, primitiveWrapperParser[wrappers.DoubleValue])

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -418,8 +418,8 @@ object JsonFormat {
       case JString(str) => Timestamps.parseTimestamp(str)
       case _ => throw new JsonFormatException("Expected a string.")
     })
-    .registerWriter((m: FieldMask) => JString(m.paths.mkString(",")), jv => jv match {
-      case JString(str) => FieldMask(if (str.isEmpty) Nil else str.split(','))
+    .registerWriter((m: FieldMask) => JString(FieldMaskUtil.toJsonString(m)), jv => jv match {
+      case JString(str) => FieldMaskUtil.fromJsonString(str)
       case _ => throw new JsonFormatException("Expected a string.")
     })
     .registerMessageFormatter[wrappers.DoubleValue](primitiveWrapperWriter, primitiveWrapperParser[wrappers.DoubleValue])

--- a/src/test/protobuf/test.proto
+++ b/src/test/protobuf/test.proto
@@ -4,6 +4,7 @@ package jsontest;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/field_mask.proto";
 
 enum MyEnum {
   UNKNOWN = 0;
@@ -53,6 +54,7 @@ message IntFields {
 message WellKnownTest {
   optional google.protobuf.Duration duration = 1;
   optional google.protobuf.Timestamp timestamp = 2;
+  optional google.protobuf.FieldMask mask = 3;
 }
 
 message DoubleFloat {

--- a/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
+++ b/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
@@ -75,17 +75,20 @@ class WellKnownTypesSpec extends FlatSpec with MustMatchers {
     JsonFormat.printer.toJson(timestampProto) must be(parse(timestampJson))
   }
 
-  "FieldMask" should "serialize to comma separated string" in {
-    val fieldMaskJson = """{"mask":"a,b"}"""
-    val fieldMaskProto = WellKnownTest(mask = Some(FieldMask(paths = Seq("a", "b"))))
+  val fieldMaskJson = """{"mask":"a,b"}"""
+  val fieldMaskProto = WellKnownTest(mask = Some(FieldMask(paths = Seq("a", "b"))))
 
-    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJson) must be(fieldMaskProto)
+  "FieldMask" should "print comma separated string" in {
     JsonFormat.printer.toJson(fieldMaskProto) must be(parse(fieldMaskJson))
 
     // Conform to protobuf-java
     JsonFormat.printer.toJson(fieldMaskProto) must be(parse(
       ProtobufJavaPrinter.print(WellKnownTest.toJavaProto(fieldMaskProto))
     ))
+  }
+
+  it should "parse comma separated string" in {
+    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJson) must be(fieldMaskProto)
 
     // Handle edge case of empty string
     val fieldMaskJsonEmpty = """{"mask":""}"""

--- a/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
+++ b/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
@@ -1,7 +1,9 @@
 package scalapb.json4s
 
 import com.google.protobuf.duration.Duration
+import com.google.protobuf.field_mask.FieldMask
 import com.google.protobuf.timestamp.Timestamp
+import com.google.protobuf.util.JsonFormat.{parser => ProtobufJavaParser, printer => ProtobufJavaPrinter}
 import jsontest.test.WellKnownTest
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{FlatSpec, MustMatchers}
@@ -71,5 +73,31 @@ class WellKnownTypesSpec extends FlatSpec with MustMatchers {
     val timestampProto = WellKnownTest(timestamp = Some(Timestamp(seconds = 1474029324, nanos = 375123456)))
     JsonFormat.parser.fromJsonString[WellKnownTest](timestampJson) must be(timestampProto)
     JsonFormat.printer.toJson(timestampProto) must be(parse(timestampJson))
+  }
+
+  "FieldMask" should "serialize to comma separated string" in {
+    val fieldMaskJson = """{"mask":"a,b"}"""
+    val fieldMaskProto = WellKnownTest(mask = Some(FieldMask(paths = Seq("a", "b"))))
+
+    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJson) must be(fieldMaskProto)
+    JsonFormat.printer.toJson(fieldMaskProto) must be(parse(fieldMaskJson))
+
+    // Conform to protobuf-java
+    JsonFormat.printer.toJson(fieldMaskProto) must be(parse(
+      ProtobufJavaPrinter.print(WellKnownTest.toJavaProto(fieldMaskProto))
+    ))
+
+    // Handle edge case of empty string
+    val fieldMaskJsonEmpty = """{"mask":""}"""
+    val fieldMaskProtoEmpty = WellKnownTest(mask = Some(FieldMask()))
+
+    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJsonEmpty) must be(fieldMaskProtoEmpty)
+
+    // Conform to protobuf-java
+    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJsonEmpty) must be {
+      val javaBuilder = jsontest.Test.WellKnownTest.newBuilder
+      ProtobufJavaParser.merge(fieldMaskJsonEmpty, javaBuilder)
+      WellKnownTest.fromJavaProto(javaBuilder.build())
+    }
   }
 }

--- a/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
+++ b/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
@@ -3,7 +3,7 @@ package scalapb.json4s
 import com.google.protobuf.duration.Duration
 import com.google.protobuf.field_mask.FieldMask
 import com.google.protobuf.timestamp.Timestamp
-import com.google.protobuf.util.JsonFormat.{parser => ProtobufJavaParser, printer => ProtobufJavaPrinter}
+import com.google.protobuf.util.JsonFormat.{printer => ProtobufJavaPrinter}
 import jsontest.test.WellKnownTest
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{FlatSpec, MustMatchers}

--- a/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
+++ b/src/test/scala/scalapb/json4s/WellKnownTypesSpec.scala
@@ -89,18 +89,5 @@ class WellKnownTypesSpec extends FlatSpec with MustMatchers {
 
   it should "parse comma separated string" in {
     JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJson) must be(fieldMaskProto)
-
-    // Handle edge case of empty string
-    val fieldMaskJsonEmpty = """{"mask":""}"""
-    val fieldMaskProtoEmpty = WellKnownTest(mask = Some(FieldMask()))
-
-    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJsonEmpty) must be(fieldMaskProtoEmpty)
-
-    // Conform to protobuf-java
-    JsonFormat.parser.fromJsonString[WellKnownTest](fieldMaskJsonEmpty) must be {
-      val javaBuilder = jsontest.Test.WellKnownTest.newBuilder
-      ProtobufJavaParser.merge(fieldMaskJsonEmpty, javaBuilder)
-      WellKnownTest.fromJavaProto(javaBuilder.build())
-    }
   }
 }


### PR DESCRIPTION
This befaviour is described at
https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto#L187-L216

also according to
https://developers.google.com/protocol-buffers/docs/proto3#json
FieldMask JSON example: "f.fooBar,h"

For now it's implemented with `mkString` and `split`
but should be replaced with `FieldMaskUtil` once
https://github.com/scalapb/ScalaPB/issues/373 is resolved