### PR TITLE
proto enums: fallback to 0-index value if present

### DIFF
--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -388,15 +388,16 @@ class Parser private (config: Parser.ParserConfig) {
     value match {
       case JInt(v) =>
         enumDescriptor.findValueByNumber(v.toInt)
-          .orElse(enumDescriptor.findValueByNumber(0))
-          .getOrElse(throw new JsonFormatException(s"Invalid enum value: ${v.toInt} for enum type: ${enumDescriptor.fullName}"))
+          .getOrElse(enumDescriptor.findValueByNumberCreatingIfUnknown(0))
+      case JString(s) if config.isIgnoringUnknownFields =>
+        enumDescriptor.values.find(_.name == s)
+          .getOrElse(NullValue.NULL_VALUE.scalaValueDescriptor)
       case JString(s) =>
         enumDescriptor.values.find(_.name == s)
-          .orElse(enumDescriptor.findValueByNumber(0))
           .getOrElse(throw new JsonFormatException(s"Unrecognized enum value '${s}'"))
-      case _ =>
-        throw new JsonFormatException(
-          s"Unexpected value ($value) for enum ${enumDescriptor.fullName}")
+      case _ => {
+          throw new JsonFormatException(s"Unexpected value ($value) for enum ${enumDescriptor.fullName}")
+      }
     }
   }
 

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -386,7 +386,7 @@ class Parser private (config: Parser.ParserConfig) {
 
   def defaultEnumParser(enumDescriptor: EnumDescriptor, value: JValue): EnumValueDescriptor = value match {
       case JInt(v) => enumDescriptor.findValueByNumber(v.toInt)
-          .getOrElse(enumDescriptor.findValueByNumberCreatingIfUnknown(0))
+          .getOrElse(enumDescriptor.findValueByNumberCreatingIfUnknown(v.toInt))
       case JString(s) if config.isIgnoringUnknownFields => enumDescriptor.values.find(_.name == s)
           .getOrElse(NullValue.NULL_VALUE.scalaValueDescriptor)
       case JString(s) => enumDescriptor.values.find(_.name == s)

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -384,22 +384,16 @@ class Parser private (config: Parser.ParserConfig) {
     }
   }
 
-  def defaultEnumParser(enumDescriptor: EnumDescriptor, value: JValue): EnumValueDescriptor = {
-    value match {
-      case JInt(v) =>
-        enumDescriptor.findValueByNumber(v.toInt)
+  def defaultEnumParser(enumDescriptor: EnumDescriptor, value: JValue): EnumValueDescriptor = value match {
+      case JInt(v) => enumDescriptor.findValueByNumber(v.toInt)
           .getOrElse(enumDescriptor.findValueByNumberCreatingIfUnknown(0))
-      case JString(s) if config.isIgnoringUnknownFields =>
-        enumDescriptor.values.find(_.name == s)
+      case JString(s) if config.isIgnoringUnknownFields => enumDescriptor.values.find(_.name == s)
           .getOrElse(NullValue.NULL_VALUE.scalaValueDescriptor)
-      case JString(s) =>
-        enumDescriptor.values.find(_.name == s)
+      case JString(s) => enumDescriptor.values.find(_.name == s)
           .getOrElse(throw new JsonFormatException(s"Unrecognized enum value '${s}'"))
-      case _ => {
+      case _ =>
           throw new JsonFormatException(s"Unexpected value ($value) for enum ${enumDescriptor.fullName}")
-      }
     }
-  }
 
   protected def parseSingleValue(containerCompanion: GeneratedMessageCompanion[_], fd: FieldDescriptor, value: JValue): PValue = fd.scalaType match {
     case ScalaType.Enum(ed) =>

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -30,7 +30,6 @@ case class Formatter[T](
 case class EnumFormatter[T](
   writer: (Printer, T) => JValue, parser: (Parser, JValue) => Option[T])
 
-
 case class FormatRegistry(
   messageFormatters: Map[Class[_], Formatter[_]] = Map.empty,
   enumFormatters: Map[EnumDescriptor, EnumFormatter[EnumValueDescriptor]] = Map.empty,
@@ -392,7 +391,6 @@ class Parser private (config: Parser.ParserConfig) {
       case JInt(v) => enumDescriptor.findValueByNumber(v.toInt)
           .orElse(Some(enumDescriptor.findValueByNumberCreatingIfUnknown(v.toInt)))
       case JString(s) if config.isIgnoringUnknownFields => enumDescriptor.values.find(_.name == s)
-          .orElse(Some(NullValue.NULL_VALUE.scalaValueDescriptor))
       case JString(s) => enumDescriptor.values.find(_.name == s)
           .orElse(throw new JsonFormatException(s"Unrecognized enum value '${s}'"))
       case _ =>

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -404,7 +404,7 @@ class Parser private (config: Parser.ParserConfig) {
         case None => defaultEnumParser(ed, value)
       }
 
-      res.map(v => PEnum(v)).getOrElse(PEmpty)
+      res.fold[PValue](PEmpty)(PEnum)
     }
     case ScalaType.Message(md) =>
       fromJsonToPMessage(containerCompanion.messageCompanionForFieldNumber(fd.number), value, false)

--- a/src/test/protobuf/test.proto
+++ b/src/test/protobuf/test.proto
@@ -42,8 +42,6 @@ message MyTest {
   }
 
   map<fixed64, bytes> fixed64_to_bytes = 18;
-  optional MyEnumWithoutDefault enum_no_default = 19;
-
 }
 
 message IntFields {
@@ -184,5 +182,7 @@ message TestAllTypes {
 
 message EnumTest {
   optional MyEnum enum = 1;
+  optional MyEnumWithoutDefault enum_no_default = 2;
+
 }
 

--- a/src/test/protobuf/test.proto
+++ b/src/test/protobuf/test.proto
@@ -12,6 +12,11 @@ enum MyEnum {
   V2 = 2;
 }
 
+enum MyEnumWithoutDefault {
+  A1 = 1;
+  A2 = 2;
+}
+
 message MyTest {
   optional string hello = 1;
   optional int32 foobar = 2;
@@ -37,6 +42,7 @@ message MyTest {
   }
 
   map<fixed64, bytes> fixed64_to_bytes = 18;
+  optional MyEnumWithoutDefault enum_no_default = 19;
 
 }
 

--- a/src/test/protobuf/test.proto
+++ b/src/test/protobuf/test.proto
@@ -182,3 +182,7 @@ message TestAllTypes {
   }
 }
 
+message EnumTest {
+  optional MyEnum enum = 1;
+}
+

--- a/src/test/protobuf/test3.proto
+++ b/src/test/protobuf/test3.proto
@@ -47,3 +47,7 @@ message StructTest {
   google.protobuf.NullValue nv = 1;
   repeated google.protobuf.NullValue rep_nv = 2;
 }
+
+message EnumTest3 {
+  MyTest3.MyEnum3 enum = 1;
+}

--- a/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
@@ -1,29 +1,37 @@
 package scalapb.json4s
 
-import jsontest.test.{EnumTest, MyEnum, MyEnumWithoutDefault, MyTest}
-import org.scalatest.{FlatSpec, MustMatchers}
+import com.google.protobuf.Message
+import jsontest.test.{EnumTest, MyEnum}
+import jsontest.test3.EnumTest3
+import jsontest.test3.MyTest3.MyEnum3
+import org.scalatest.{Assertion, FlatSpec, MustMatchers}
+import scalapb.GeneratedMessageCompanion
 
 class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
 
-  "TestProto" should "infer default value when present" in {
-    new Parser().fromJsonString[EnumTest]("""{"enum":10}""") must be(EnumTest(enum = Some(MyEnum.Unrecognized(10))))
+  "EnumTest" should "be none for non-existent int value - proto2" in {
+    new Parser().fromJsonString[EnumTest]("""{"enum":10}""") must be(EnumTest(enum = None))
   }
 
-  "TestProto" should "return `Unrecognized` when 0-index enum is not present" in {
-    new Parser().fromJsonString[EnumTest]("""{"enum_no_default":10}""") must be(EnumTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(10))))
+  "EnumTest" should "return `Unrecognized` for non-existent int value - proto3" in {
+    new Parser().fromJsonString[EnumTest3]("""{"enum":10}""") must be(EnumTest3(enum =  MyEnum3.Unrecognized(10)))
   }
 
-  "TestProto" should "fail for unknown string enum value" in {
+  "TestProto" should "fail for unknown string enum value - proto2/proto3" in {
     assertThrows[JsonFormatException](
       new Parser().fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")
     )
+    assertThrows[JsonFormatException](
+      new Parser().fromJsonString[EnumTest3]("""{"enum":"ZAZA"}""")
+    )
   }
 
-  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set" in {
+  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set - proto3/proto3" in {
     new Parser().ignoringUnknownFields
       .fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")  must be(EnumTest(enum = None))
+    new Parser().ignoringUnknownFields
+      .fromJsonString[EnumTest3]("""{"enum":"ZAZA"}""")  must be(EnumTest3(enum = MyEnum3.UNKNOWN))
   }
-
 
   "Enum" should "be serialized the same way as java" in {
     assertJsonIsSameAsJava(jsontest.test.EnumTest())
@@ -31,23 +39,40 @@ class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
   }
 
   "Enum" should "be parsed the same way as java - non-existent string value" in {
-    val parser = JavaJsonParser.ignoringUnknownFields()
-    val enumJson = """{"enum": "XOXO"}"""
+    assertParse[jsontest.test.EnumTest, jsontest.Test.EnumTest](
+      """{"enum": "XOXO"}""",
+      jsontest.Test.EnumTest.newBuilder,
+      javaProto => EnumTest.fromJavaProto(javaProto))
 
-    javaParse(enumJson, jsontest.Test.EnumTest.newBuilder, parser).toString must be("")
-    new Parser().ignoringUnknownFields.fromJsonString[jsontest.test.EnumTest](enumJson) must be(
-      jsontest.test.EnumTest(None)
-    )
+    assertParse[EnumTest3, jsontest.Test3.EnumTest3](
+      """{"enum": "XOXO"}""",
+      jsontest.Test3.EnumTest3.newBuilder,
+      javaProto => EnumTest3.fromJavaProto(javaProto))
   }
 
   "Enum" should "be parsed the same way as java - non-existent int value" in {
-    val parser = JavaJsonParser.ignoringUnknownFields()
-    val enumJson = """{"enum": 10}"""
+    assertParse[jsontest.test.EnumTest, jsontest.Test.EnumTest](
+      """{"enum": 10}""",
+      jsontest.Test.EnumTest.newBuilder,
+      javaProto => EnumTest.fromJavaProto(javaProto))
 
-    javaParse(enumJson, jsontest.Test.EnumTest.newBuilder, parser).toString must be("")
-    new Parser().ignoringUnknownFields.fromJsonString[jsontest.test.EnumTest](enumJson) must be(
-      jsontest.test.EnumTest(Some(MyEnum.Unrecognized(10)))
-    )
+    assertParse[EnumTest3, jsontest.Test3.EnumTest3](
+      """{"enum": 10}""",
+      jsontest.Test3.EnumTest3.newBuilder,
+      javaProto => EnumTest3.fromJavaProto(javaProto))
+  }
+
+  def assertParse[T <: scalapb.GeneratedMessage with scalapb.Message[T], J](
+                                                                          json: String,
+                                                                          builder: Message.Builder,
+                                                                          fromJavaProto: J => T)(
+    implicit cmp: GeneratedMessageCompanion[T]): Assertion = {
+    val parser = JavaJsonParser.ignoringUnknownFields()
+    parser.merge(json, builder)
+
+    val scala = new Parser().ignoringUnknownFields.fromJsonString[T](json)
+
+    fromJavaProto(builder.build().asInstanceOf[J]) must be(scala)
   }
 
 }

--- a/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
@@ -1,16 +1,36 @@
 package scalapb.json4s
 
-import jsontest.test.MyEnum
+import jsontest.test.{EnumTest, MyEnum, MyEnumWithoutDefault, MyTest}
 import org.scalatest.{FlatSpec, MustMatchers}
 
 class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
+
+  "TestProto" should "infer default value when present" in {
+    new Parser().fromJsonString[EnumTest]("""{"enum":10}""") must be(EnumTest(enum = Some(MyEnum.Unrecognized(10))))
+  }
+
+  "TestProto" should "return `Unrecognized` when 0-index enum is not present" in {
+    new Parser().fromJsonString[EnumTest]("""{"enum_no_default":10}""") must be(EnumTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(10))))
+  }
+
+  "TestProto" should "fail for unknown string enum value" in {
+    assertThrows[JsonFormatException](
+      new Parser().fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")
+    )
+  }
+
+  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set" in {
+    new Parser().ignoringUnknownFields
+      .fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")  must be(EnumTest(enum = None))
+  }
+
 
   "Enum" should "be serialized the same way as java" in {
     assertJsonIsSameAsJava(jsontest.test.EnumTest())
     assertJsonIsSameAsJava(jsontest.test.EnumTest(Some(MyEnum.V1)))
   }
 
-  "Enum" should "be serialized the same way as java - non-existent string value" in {
+  "Enum" should "be parsed the same way as java - non-existent string value" in {
     val parser = JavaJsonParser.ignoringUnknownFields()
     val enumJson = """{"enum": "XOXO"}"""
 
@@ -20,7 +40,7 @@ class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
     )
   }
 
-  "Enum" should "be serialized the same way as java - non-existent int value" in {
+  "Enum" should "be parsed the same way as java - non-existent int value" in {
     val parser = JavaJsonParser.ignoringUnknownFields()
     val enumJson = """{"enum": 10}"""
 

--- a/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
@@ -9,15 +9,15 @@ import scalapb.GeneratedMessageCompanion
 
 class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
 
-  "EnumTest" should "be none for non-existent int value - proto2" in {
+  "MyEnum" should "be none for non-existent int value - proto2" in {
     new Parser().fromJsonString[EnumTest]("""{"enum":10}""") must be(EnumTest(enum = None))
   }
 
-  "EnumTest" should "return `Unrecognized` for non-existent int value - proto3" in {
+  "MyEnum" should "be set to `Unrecognized` for non-existent int value - proto3" in {
     new Parser().fromJsonString[EnumTest3]("""{"enum":10}""") must be(EnumTest3(enum =  MyEnum3.Unrecognized(10)))
   }
 
-  "TestProto" should "fail for unknown string enum value - proto2/proto3" in {
+  "EnumTest" should "fail for unknown string enum value - proto2/proto3" in {
     assertThrows[JsonFormatException](
       new Parser().fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")
     )
@@ -26,7 +26,7 @@ class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
     )
   }
 
-  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set - proto3/proto3" in {
+  "EnumTest" should "not fail for unknown enum values when `ignoringUnknownFields` is set - proto2/proto3" in {
     new Parser().ignoringUnknownFields
       .fromJsonString[EnumTest]("""{"enum":"ZAZA"}""")  must be(EnumTest(enum = None))
     new Parser().ignoringUnknownFields
@@ -38,7 +38,7 @@ class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
     assertJsonIsSameAsJava(jsontest.test.EnumTest(Some(MyEnum.V1)))
   }
 
-  "Enum" should "be parsed the same way as java - non-existent string value" in {
+  "EnumTest" should "be parsed the same way as java - non-existent string value - proto2/proto3" in {
     assertParse[jsontest.test.EnumTest, jsontest.Test.EnumTest](
       """{"enum": "XOXO"}""",
       jsontest.Test.EnumTest.newBuilder,
@@ -50,7 +50,7 @@ class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
       javaProto => EnumTest3.fromJavaProto(javaProto))
   }
 
-  "Enum" should "be parsed the same way as java - non-existent int value" in {
+  "EnumTest" should "be parsed the same way as java - non-existent int value - proto2/proto3" in {
     assertParse[jsontest.test.EnumTest, jsontest.Test.EnumTest](
       """{"enum": 10}""",
       jsontest.Test.EnumTest.newBuilder,

--- a/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/EnumFormatSpec.scala
@@ -1,0 +1,33 @@
+package scalapb.json4s
+
+import jsontest.test.MyEnum
+import org.scalatest.{FlatSpec, MustMatchers}
+
+class EnumFormatSpec extends FlatSpec with MustMatchers with JavaAssertions {
+
+  "Enum" should "be serialized the same way as java" in {
+    assertJsonIsSameAsJava(jsontest.test.EnumTest())
+    assertJsonIsSameAsJava(jsontest.test.EnumTest(Some(MyEnum.V1)))
+  }
+
+  "Enum" should "be serialized the same way as java - non-existent string value" in {
+    val parser = JavaJsonParser.ignoringUnknownFields()
+    val enumJson = """{"enum": "XOXO"}"""
+
+    javaParse(enumJson, jsontest.Test.EnumTest.newBuilder, parser).toString must be("")
+    new Parser().ignoringUnknownFields.fromJsonString[jsontest.test.EnumTest](enumJson) must be(
+      jsontest.test.EnumTest(None)
+    )
+  }
+
+  "Enum" should "be serialized the same way as java - non-existent int value" in {
+    val parser = JavaJsonParser.ignoringUnknownFields()
+    val enumJson = """{"enum": 10}"""
+
+    javaParse(enumJson, jsontest.Test.EnumTest.newBuilder, parser).toString must be("")
+    new Parser().ignoringUnknownFields.fromJsonString[jsontest.test.EnumTest](enumJson) must be(
+      jsontest.test.EnumTest(Some(MyEnum.Unrecognized(10)))
+    )
+  }
+
+}

--- a/src/test/scala/scalapb/json4s/JavaAssertions.scala
+++ b/src/test/scala/scalapb/json4s/JavaAssertions.scala
@@ -1,5 +1,6 @@
 package scalapb.json4s
 
+import com.google.protobuf.util.JsonFormat
 import com.google.protobuf.util.JsonFormat.{TypeRegistry => JavaTypeRegistry}
 import org.scalatest.MustMatchers
 import scalapb.json4s.JsonFormat.GenericCompanion
@@ -33,8 +34,11 @@ trait JavaAssertions {
     }
   }
 
-  def javaParse[T <: com.google.protobuf.GeneratedMessageV3.Builder[T]](json: String, b: com.google.protobuf.GeneratedMessageV3.Builder[T]) = {
-    JavaJsonParser.merge(json, b)
+  def javaParse[T <: com.google.protobuf.GeneratedMessageV3.Builder[T]](
+      json: String,
+      b: com.google.protobuf.GeneratedMessageV3.Builder[T],
+      parser: com.google.protobuf.util.JsonFormat.Parser = JavaJsonParser) = {
+    parser.merge(json, b)
     b.build()
   }
 

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -223,7 +223,8 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
           |  "stringToBool": {},
           |  "optBs": "",
           |  "optBool": false,
-          |  "fixed64ToBytes": {}
+          |  "fixed64ToBytes": {},
+          |  "enumNoDefault": "A1"
           |}""".stripMargin)
     )
   }
@@ -246,7 +247,8 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
           |  "string_to_bool": {},
           |  "opt_bs": "",
           |  "opt_bool": false,
-          |  "fixed64_to_bytes": {}
+          |  "fixed64_to_bytes": {},
+          |  "enum_no_default": "A1"
           |}""".stripMargin)
     )
   }
@@ -341,6 +343,16 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
   "TestProto" should "parse original field names" in {
     new Parser().fromJsonString[MyTest]("""{"opt_enum":1}""") must be(MyTest(optEnum = Some(MyEnum.V1)))
     new Parser().fromJsonString[MyTest]("""{"opt_enum":2}""") must be(MyTest(optEnum = Some(MyEnum.V2)))
+  }
+
+  "TestProto" should "infer default value when present" in {
+    new Parser().fromJsonString[MyTest]("""{"opt_enum":10}""") must be(MyTest(optEnum = Some(MyEnum.UNKNOWN)))
+  }
+
+  "TestProto" should "fail when default value not present" in {
+    assertThrows[JsonFormatException](
+      new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""")
+    )
   }
 
   "PreservedTestJson" should "be TestProto when parsed from json" in {

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -349,10 +349,19 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
     new Parser().fromJsonString[MyTest]("""{"opt_enum":10}""") must be(MyTest(optEnum = Some(MyEnum.UNKNOWN)))
   }
 
-  "TestProto" should "fail when default value not present" in {
+  "TestProto" should "return `Unrecognized` when 0-index enum is not present" in {
+    new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""") must be(MyTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(0))))
+  }
+
+  "TestProto" should "fail for unknown string enum value" in {
     assertThrows[JsonFormatException](
-      new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""")
+      new Parser().fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")
     )
+  }
+
+  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set" in {
+      new Parser().ignoringUnknownFields
+        .fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")  must be(MyTest(optEnum = Some(MyEnum.UNKNOWN)))
   }
 
   "PreservedTestJson" should "be TestProto when parsed from json" in {

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -346,11 +346,11 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
   }
 
   "TestProto" should "infer default value when present" in {
-    new Parser().fromJsonString[MyTest]("""{"opt_enum":10}""") must be(MyTest(optEnum = Some(MyEnum.UNKNOWN)))
+    new Parser().fromJsonString[MyTest]("""{"opt_enum":10}""") must be(MyTest(optEnum = Some(MyEnum.Unrecognized(10))))
   }
 
   "TestProto" should "return `Unrecognized` when 0-index enum is not present" in {
-    new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""") must be(MyTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(0))))
+    new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""") must be(MyTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(10))))
   }
 
   "TestProto" should "fail for unknown string enum value" in {

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -156,9 +156,9 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
   }
 
   "JsonFormat" should "encode and decode enums for proto3" in {
-    val v1Value = MyTest3(optEnum = MyTest3.MyEnum3.V1)
+    val v1Value = MyTest3(optEnum = MyEnum3.V1)
     JsonFormat.toJson(v1Value) must be (parse("""{"optEnum": "V1"}"""))
-    val defaultValue = MyTest3(optEnum = MyTest3.MyEnum3.UNKNOWN)
+    val defaultValue = MyTest3(optEnum = MyEnum3.UNKNOWN)
     JsonFormat.toJson(defaultValue) must be (parse("""{}"""))
     JsonFormat.fromJsonString[MyTest3](JsonFormat.toJsonString(v1Value)) must be(v1Value)
     JsonFormat.fromJsonString[MyTest3](JsonFormat.toJsonString(defaultValue)) must be(defaultValue)

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -223,8 +223,7 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
           |  "stringToBool": {},
           |  "optBs": "",
           |  "optBool": false,
-          |  "fixed64ToBytes": {},
-          |  "enumNoDefault": "A1"
+          |  "fixed64ToBytes": {}
           |}""".stripMargin)
     )
   }
@@ -247,8 +246,7 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
           |  "string_to_bool": {},
           |  "opt_bs": "",
           |  "opt_bool": false,
-          |  "fixed64_to_bytes": {},
-          |  "enum_no_default": "A1"
+          |  "fixed64_to_bytes": {}
           |}""".stripMargin)
     )
   }
@@ -343,25 +341,6 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
   "TestProto" should "parse original field names" in {
     new Parser().fromJsonString[MyTest]("""{"opt_enum":1}""") must be(MyTest(optEnum = Some(MyEnum.V1)))
     new Parser().fromJsonString[MyTest]("""{"opt_enum":2}""") must be(MyTest(optEnum = Some(MyEnum.V2)))
-  }
-
-  "TestProto" should "infer default value when present" in {
-    new Parser().fromJsonString[MyTest]("""{"opt_enum":10}""") must be(MyTest(optEnum = Some(MyEnum.Unrecognized(10))))
-  }
-
-  "TestProto" should "return `Unrecognized` when 0-index enum is not present" in {
-    new Parser().fromJsonString[MyTest]("""{"enum_no_default":10}""") must be(MyTest(enumNoDefault = Some(MyEnumWithoutDefault.Unrecognized(10))))
-  }
-
-  "TestProto" should "fail for unknown string enum value" in {
-    assertThrows[JsonFormatException](
-      new Parser().fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")
-    )
-  }
-
-  "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set" in {
-      new Parser().ignoringUnknownFields
-        .fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")  must be(MyTest(optEnum = None))
   }
 
   "PreservedTestJson" should "be TestProto when parsed from json" in {

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -156,9 +156,9 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
   }
 
   "JsonFormat" should "encode and decode enums for proto3" in {
-    val v1Value = MyTest3(optEnum = MyEnum3.V1)
+    val v1Value = MyTest3(optEnum = MyTest3.MyEnum3.V1)
     JsonFormat.toJson(v1Value) must be (parse("""{"optEnum": "V1"}"""))
-    val defaultValue = MyTest3(optEnum = MyEnum3.UNKNOWN)
+    val defaultValue = MyTest3(optEnum = MyTest3.MyEnum3.UNKNOWN)
     JsonFormat.toJson(defaultValue) must be (parse("""{}"""))
     JsonFormat.fromJsonString[MyTest3](JsonFormat.toJsonString(v1Value)) must be(v1Value)
     JsonFormat.fromJsonString[MyTest3](JsonFormat.toJsonString(defaultValue)) must be(defaultValue)

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -361,7 +361,7 @@ class JsonFormatSpec extends FlatSpec with MustMatchers with OptionValues with J
 
   "TestProto" should "not fail for unknown enum values when `ignoringUnknownFields` is set" in {
       new Parser().ignoringUnknownFields
-        .fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")  must be(MyTest(optEnum = Some(MyEnum.UNKNOWN)))
+        .fromJsonString[MyTest]("""{"opt_enum":"ZAZA"}""")  must be(MyTest(optEnum = None))
   }
 
   "PreservedTestJson" should "be TestProto when parsed from json" in {


### PR DESCRIPTION
As per [proto3 spec](https://developers.google.com/protocol-buffers/docs/proto3#default)  - `For enums, the default value is the first defined enum value, which must be 0.`

I added fallback to `0`-index value if present or previous behavior if not.