### PR TITLE
Fix PrimitiveWrapper scalar serialization (https://github.com/scalapb/ScalaPB/issues/727)

### DIFF
--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -370,7 +370,7 @@ class Printer private (config: Printer.PrinterConfig) {
   def serializeSingleValue(
       fd: FieldDescriptor,
       value: PValue,
-      formattingLongAsNumber: Boolean
+      formattingLongAsNumber: Boolean = config.isFormattingLongAsNumber
   ): JValue = value match {
     case PEnum(e) =>
       config.formatRegistry.getEnumWriter(e.containingEnum) match {
@@ -729,8 +729,7 @@ object JsonFormat {
     (printer, t) =>
       printer.serializeSingleValue(
         fieldDesc,
-        t.getField(fieldDesc),
-        formattingLongAsNumber = false
+        t.getField(fieldDesc)
       )
   }
 

--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -270,8 +270,7 @@ class Printer private (config: Printer.PrinterConfig) {
               } else {
                 serializeSingleValue(
                   valueDescriptor,
-                  x.getField(valueDescriptor),
-                  config.isFormattingLongAsNumber
+                  x.getField(valueDescriptor)
                 )
               }
               key -> value
@@ -304,7 +303,7 @@ class Printer private (config: Printer.PrinterConfig) {
             name,
             JArray(
               xs.map(
-                  serializeSingleValue(fd, _, config.isFormattingLongAsNumber)
+                  serializeSingleValue(fd, _)
                 )
                 .toList
             )
@@ -318,7 +317,7 @@ class Printer private (config: Printer.PrinterConfig) {
             fd.containingOneof.isDefined) {
           b += JField(
             name,
-            serializeSingleValue(fd, v, config.isFormattingLongAsNumber)
+            serializeSingleValue(fd, v)
           )
         }
     }
@@ -348,8 +347,7 @@ class Printer private (config: Printer.PrinterConfig) {
   private def defaultJValue(fd: FieldDescriptor): JValue =
     serializeSingleValue(
       fd,
-      JsonFormat.defaultValue(fd),
-      config.isFormattingLongAsNumber
+      JsonFormat.defaultValue(fd)
     )
 
   private def unsignedInt(n: Int): Long = n & 0X00000000FFFFFFFFL
@@ -367,10 +365,14 @@ class Printer private (config: Printer.PrinterConfig) {
     if (formattingLongAsNumber) JInt(v) else JString(v.toString())
   }
 
+  def serializeSingleValue(fd: FieldDescriptor, value: PValue): JValue = {
+    serializeSingleValue(fd, value, config.isFormattingLongAsNumber)
+  }
+
   def serializeSingleValue(
       fd: FieldDescriptor,
       value: PValue,
-      formattingLongAsNumber: Boolean = config.isFormattingLongAsNumber
+      formattingLongAsNumber: Boolean
   ): JValue = value match {
     case PEnum(e) =>
       config.formatRegistry.getEnumWriter(e.containingEnum) match {

--- a/src/test/scala/scalapb/json4s/PrimitiveWrappersSpec.scala
+++ b/src/test/scala/scalapb/json4s/PrimitiveWrappersSpec.scala
@@ -2,7 +2,7 @@ package scalapb.json4s
 
 import com.google.protobuf.ByteString
 import jsontest.test3._
-import org.json4s.JsonAST.{JBool, JDecimal, JDouble, JString}
+import org.json4s.JsonAST.{JBool, JDecimal, JDouble, JLong, JString}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{JInt, JValue}
@@ -57,6 +57,12 @@ class PrimitiveWrappersSpec
     JsonFormat.toJson(Wrapper(wBytes = Some(ByteString.EMPTY))) must be(
       render(Map("wBytes" -> JString("")))
     )
+  }
+
+  "primitive values" should "serialize with printer config" in {
+    new Printer().formattingLongAsNumber.toJson(
+      Wrapper(wInt64 = Some(123456))
+    ) must be(render(Map("wInt64" -> JInt(123456))))
   }
 
   "primitive values" should "parse properly" in new DefaultParserContext {

--- a/src/test/scala/scalapb/json4s/PrimitiveWrappersSpec.scala
+++ b/src/test/scala/scalapb/json4s/PrimitiveWrappersSpec.scala
@@ -2,7 +2,7 @@ package scalapb.json4s
 
 import com.google.protobuf.ByteString
 import jsontest.test3._
-import org.json4s.JsonAST.{JBool, JDecimal, JDouble, JLong, JString}
+import org.json4s.JsonAST.{JBool, JDecimal, JDouble, JString}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{JInt, JValue}


### PR DESCRIPTION
Closes https://github.com/scalapb/ScalaPB/issues/727 

There was a small problem in that `primitiveWrapperWriter` is external to `Printer`, but `PrinterConfig` is entirely encapsulated.  I could work around it by using a default value,
but alternatively I could change `PrinterConfig` so it would be visible, at least to `JsonFormat`. 


 