### PR TITLE
add case for matching Array[GeneratedMessage] 

### DIFF
--- a/src/test/protobuf/custom_collection.proto
+++ b/src/test/protobuf/custom_collection.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "jsontest";
 import "scalapb/scalapb.proto";
+import "google/protobuf/wrappers.proto";
 
 message Guitar {
   int32 number_of_strings = 1;
@@ -10,8 +11,6 @@ message Guitar {
 message Studio {
   repeated Guitar guitars = 1 [(scalapb.field).collection_type = "Set"];
 }
-
-import "google/protobuf/wrappers.proto";
 
 message GoogleWrapped {
   repeated google.protobuf.StringValue strings = 1 [(scalapb.field).collection_type = "scala.collection.immutable.Seq"];

--- a/src/test/protobuf/custom_collection.proto
+++ b/src/test/protobuf/custom_collection.proto
@@ -10,3 +10,9 @@ message Guitar {
 message Studio {
   repeated Guitar guitars = 1 [(scalapb.field).collection_type = "Set"];
 }
+
+import "google/protobuf/wrappers.proto";
+
+message GoogleWrapped {
+  repeated google.protobuf.StringValue strings = 1 [(scalapb.field).collection_type = "scala.collection.immutable.Seq"];
+}

--- a/src/test/scala/scalapb/json4s/CustomCollectionSpec.scala
+++ b/src/test/scala/scalapb/json4s/CustomCollectionSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.must.Matchers
 
 class CustomCollectionSpec extends AnyFlatSpec with Matchers {
   "JsonFormat" should "serialize/deserialize the custom collection message" in {
-    val googleWrapped = GoogleWrapped(strings = Seq.empty)
+    val googleWrapped = GoogleWrapped(strings = collection.immutable.Seq.empty)
     val json = JsonFormat.toJson(googleWrapped)
     JsonFormat.fromJson[GoogleWrapped](json) mustBe googleWrapped
   }

--- a/src/test/scala/scalapb/json4s/CustomCollectionSpec.scala
+++ b/src/test/scala/scalapb/json4s/CustomCollectionSpec.scala
@@ -1,0 +1,13 @@
+package scalapb.json4s
+
+import jsontest.custom_collection.GoogleWrapped
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class CustomCollectionSpec extends AnyFlatSpec with Matchers {
+  "JsonFormat" should "serialize/deserialize the custom collection message" in {
+    val googleWrapped = GoogleWrapped(strings = Seq.empty)
+    val json = JsonFormat.toJson(googleWrapped)
+    JsonFormat.fromJson[GoogleWrapped](json) mustBe googleWrapped
+  }
+}


### PR DESCRIPTION
add case for matching Array[GeneratedMessage] and convert it implicitly to Iterable by serialization

to work around the issue in early 0.10.x version [https://github.com/scalapb/ScalaPB/issues/1121]