### PR TITLE
add a parser option to validate oneofs

### DIFF
--- a/src/test/scala/scalapb/json4s/JavaAssertions.scala
+++ b/src/test/scala/scalapb/json4s/JavaAssertions.scala
@@ -31,13 +31,6 @@ class IgnoringUnknownParserContext {
   )
 }
 
-class StrictOneofParserContext {
-  implicit val pc: ParserContext = ParserContext(
-    new Parser().failOnOverlappingOneofKeys,
-    JavaJsonFormat.parser // by default the java parser fails on overlapping keys
-  )
-}
-
 trait JavaAssertions {
   self: AnyFlatSpec with Matchers =>
 

--- a/src/test/scala/scalapb/json4s/JavaAssertions.scala
+++ b/src/test/scala/scalapb/json4s/JavaAssertions.scala
@@ -31,6 +31,13 @@ class IgnoringUnknownParserContext {
   )
 }
 
+class StrictOneofParserContext {
+  implicit val pc: ParserContext = ParserContext(
+    new Parser().failOnOverlappingOneofKeys,
+    JavaJsonFormat.parser // by default the java parser fails on overlapping keys
+  )
+}
+
 trait JavaAssertions {
   self: AnyFlatSpec with Matchers =>
 

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -675,14 +675,15 @@ class JsonFormatSpec
     JsonFormat.parser.fromJsonString[TestAllTypes](javaJson) must be(obj)
   }
 
-  "oneofs" should "fail for overlapping keys if failOnOverlappingOneofKeys" in new StrictOneofParserContext {
+  "oneofs" should "fail for overlapping keys if failOnOverlappingOneofKeys" in new DefaultParserContext {
     val extraKey = """{"primitive": "", "wrapper": ""}"""
     assertFails(extraKey, OneOf)
   }
 
-  "oneofs" should "not fail for overlapping keys if failOnOverlappingOneofKeys with a scala parser" in new DefaultParserContext {
+  "oneofs" should "not fail for overlapping keys if ignoreOverlappingOneofKeys" in {
     val extraKey = """{"primitive": "", "wrapper": ""}"""
-    val parsedScala = pc.scalaParser.fromJsonString[OneOf](extraKey)(OneOf)
+    val scalaParser = new Parser().ignoringOverlappingOneofFields
+    val parsedScala = scalaParser.fromJsonString[OneOf](extraKey)(OneOf)
     parsedScala must be(
       OneOf(field = OneOf.Field.Primitive(""))
     )

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -7,6 +7,7 @@ import com.google.protobuf.any.{Any => PBAny}
 import com.google.protobuf.util.JsonFormat.{TypeRegistry => JavaTypeRegistry}
 import com.google.protobuf.util.{JsonFormat => JavaJsonFormat}
 import jsontest.custom_collection.{Guitar, Studio}
+import jsontest.oneof.OneOf
 import jsontest.test._
 import jsontest.test3._
 import org.json4s.JsonDSL._
@@ -672,6 +673,19 @@ class JsonFormatSpec
     scalaJson must be(parse(javaJson, useBigDecimalForDouble = true))
 
     JsonFormat.parser.fromJsonString[TestAllTypes](javaJson) must be(obj)
+  }
+
+  "oneofs" should "fail for overlapping keys if failOnOverlappingOneofKeys" in new StrictOneofParserContext {
+    val extraKey = """{"primitive": "", "wrapper": ""}"""
+    assertFails(extraKey, OneOf)
+  }
+
+  "oneofs" should "not fail for overlapping keys if failOnOverlappingOneofKeys with a scala parser" in new DefaultParserContext {
+    val extraKey = """{"primitive": "", "wrapper": ""}"""
+    val parsedScala = pc.scalaParser.fromJsonString[OneOf](extraKey)(OneOf)
+    parsedScala must be(
+      OneOf(field = OneOf.Field.Primitive(""))
+    )
   }
 
   "TestProto" should "be TestJsonWithMapEntriesAsKeyValuePairs when converted to Proto with mapEntriesAsKeyValuePairs setting" in {


### PR DESCRIPTION
The exception looks like:
```
scalapb.json4s.JsonFormatException: Overlapping keys in oneof: primitive, wrapper
```

Here's a first pass. I'm definitely open to feedback re: different approaches and style. 

The java-parser was already throwing an `InvalidProtocolBufferException` for too many keys (and this is now part of the unit tests).

I wasn't thrilled with the placement of `validateOneofs()`, but it seemed better and easier than working with the generated code to modify the `Reads`