### PR TITLE
support scalapb-runtime_3's scalapb.descriptors.PEnum$

### DIFF
--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -698,7 +698,7 @@ class Parser private (config: Parser.ParserConfig) {
             case None         => defaultEnumParser(ed, value)
           }
 
-        res.fold[PValue](PEmpty)(PEnum)
+        res.fold[PValue](PEmpty)(PEnum.apply)
       }
       case ScalaType.Message(md) =>
         fromJsonToPMessage(


### PR DESCRIPTION
Towards https://github.com/scalapb/ScalaPB/issues/1174 (see `IncompatibleClassChangeError` there)

Obviously the end goal would be to cross-build for 3.0 but json4s is not yet available. Before that, overall compatibility of scalapb-json4s_2.13 towards scalapb-runtime-3 could be checked with CI, but I didn't have time to go that far (and it's blocked by https://github.com/scalapb/ScalaPB/pull/1175 anyway).