### PR TITLE
fix uint32 parsing with floating point zeros

### DIFF
--- a/src/main/scala/scalapb/json4s/JsonFormat.scala
+++ b/src/main/scala/scalapb/json4s/JsonFormat.scala
@@ -1028,7 +1028,7 @@ object JsonFormat {
     parseBigDecimal(value).toBigIntExact.map { intVal =>
       if (intVal < 0 || intVal > 0xffffffffL)
         throw new JsonFormatException(s"Out of range uint32 value: $value")
-      PLong(intVal.intValue)
+      PInt(intVal.intValue)
     } getOrElse {
       throw new JsonFormatException(s"Not an uint32 value: $value")
     }

--- a/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
+++ b/src/test/scala/scalapb/json4s/JsonFormatSpec.scala
@@ -357,6 +357,10 @@ class JsonFormatSpec
       s"""{"uint":"$uint32max"}""",
       IntFields(uint = Some(uint32max.toInt))
     )
+    validateAccepts(
+      s"""{"uint":"$uint32max.0"}""",
+      IntFields(uint = Some(uint32max.toInt))
+    )
     validateRejects(s"""{"uint":"${uint32max + 1}"}""")
     validateRejects("""{"uint":"-1"}""")
 
@@ -364,6 +368,10 @@ class JsonFormatSpec
     val uint64max: BigInt = (BigInt(1) << 64) - 1
     validateAccepts(
       s"""{"ulong":"$uint64max"}""",
+      IntFields(ulong = Some(uint64max.toLong))
+    )
+    validateAccepts(
+      s"""{"ulong":"$uint64max.0"}""",
       IntFields(ulong = Some(uint64max.toLong))
     )
     validateRejects(s"""{"ulong":"${uint64max + 1}"}""")


### PR DESCRIPTION
Now in case value for uint has floating point shape (1.0) parser fails because it produces PLong instead of PInt (though value is within bounds).
```
[info] - should parse numbers formatted as JSON string *** FAILED ***
[info]   scalapb.descriptors.ReadsException: Expected PInt
[info]   at scalapb.descriptors.Reads$.$anonfun$intReads$1(PValue.scala:38)
[info]   at scalapb.descriptors.Reads$.$anonfun$intReads$1$adapted(PValue.scala:36)
[info]   at scalapb.descriptors.Reads$.$anonfun$optional$1(PValue.scala:78)
[info]   at scalapb.descriptors.PValue.as(PValue.scala:6)
[info]   at scalapb.descriptors.PValue.as$(PValue.scala:6)
[info]   at scalapb.descriptors.PLong.as(PValue.scala:13)
[info]   at jsontest.test.IntFields$.$anonfun$messageReads$6(IntFields.scala:239)
[info]   at scala.Option.flatMap(Option.scala:283)
[info]   at jsontest.test.IntFields$.$anonfun$messageReads$1(IntFields.scala:239)
[info]   at scalapb.json4s.Parser.fromJson(JsonFormat.scala:538)
```

In my own codebase we tried sedes and it faild (though jackson is involved in ser part). Checked java impl - type system is different, but this change retains symmetricity with java.



